### PR TITLE
optimize pass export

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${inter.className} min-h-dvh flex flex-col justify-between`}
         style={{
-          background: "url('bg.png')",
+          background: "url('/bg.png')",
           backgroundSize: 'cover',
           backgroundPosition: 'center',
           backgroundAttachment: 'fixed',

--- a/apps/frontend/src/app/periods/[id]/pass-export.tsx
+++ b/apps/frontend/src/app/periods/[id]/pass-export.tsx
@@ -6,6 +6,7 @@ type Props = {
   applicationData: ApplicationEntity[];
   periodName: string;
   periodId: number;
+  cacheBuster: number;
   mock?: boolean;
 };
 
@@ -14,7 +15,7 @@ Font.register({
   src: 'https://cdnjs.cloudflare.com/ajax/libs/ink/3.1.10/fonts/Roboto/roboto-regular-webfont.ttf',
 });
 
-export const PassExport = ({ applicationData, periodName, periodId, mock = false }: Props) => (
+export const PassExport = ({ applicationData, periodName, periodId, cacheBuster, mock = false }: Props) => (
   <Document>
     <Page
       size='A4'
@@ -27,8 +28,7 @@ export const PassExport = ({ applicationData, periodName, periodId, mock = false
       {applicationData.map((a) => (
         <View key={a.id}>
           <Image
-            cache={false}
-            src={`${process.env.NEXT_PUBLIC_API_URL}/application-periods/${periodId}/pass-bg`}
+            src={`${process.env.NEXT_PUBLIC_API_URL}/application-periods/${periodId}/pass-bg?cb=${cacheBuster}`}
             style={{ width: '7.5cm', height: '4.3cm', position: 'absolute', top: 0, left: 0, zIndex: -1 }}
           />
 

--- a/apps/frontend/src/components/ui/AdminApplicationPeriodCard.tsx
+++ b/apps/frontend/src/components/ui/AdminApplicationPeriodCard.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
 import { mutate } from 'swr';
 
 import { PassExport } from '@/app/periods/[id]/pass-export';
@@ -28,8 +27,13 @@ import { ApplicationPeriodEntity } from '@/types/application-period-entity';
 import { Th2 } from '../typography/typography';
 import PictureUploadDialog from './PictureUploadDialog';
 
-export default function AdminApplicationPeriodCard({ period }: { period: ApplicationPeriodEntity }) {
-  const [cacheBuster, setCacheBuster] = useState(Date.now());
+type Props = {
+  period: ApplicationPeriodEntity;
+  cacheBuster: number;
+  setCacheBuster: (n: number) => void;
+};
+
+export default function AdminApplicationPeriodCard({ period, cacheBuster, setCacheBuster }: Props) {
   const router = useRouter();
   const deleteApplicationPeriod = async () => {
     const response = await api.delete(`/application-periods/${period.id}`).catch((e) => {
@@ -58,14 +62,14 @@ export default function AdminApplicationPeriodCard({ period }: { period: Applica
     await mutate(`/application-periods/${period.id}`);
   };
 
-  const onDummyExport = async () => {
-    const now = new Date();
+  const onMockExport = async () => {
     downloadPdf(
       <PassExport
         mock
         periodId={period.id}
         applicationData={[mockApplication]}
-        periodName={`${now.getFullYear()}. ${now.getMonth() < 7 ? 'tavasz' : 'ősz'}`}
+        periodName={period.name}
+        cacheBuster={cacheBuster}
       />,
       `schbody_pass_mock_export_${Date.now()}.pdf`
     );
@@ -142,7 +146,7 @@ export default function AdminApplicationPeriodCard({ period }: { period: Applica
               Szerkesztés
             </Button>
           </PictureUploadDialog>
-          <Button variant='secondary' className='max-md:w-full' onClick={onDummyExport}>
+          <Button variant='secondary' className='max-md:w-full' onClick={onMockExport}>
             Minta belépő generálása
           </Button>
         </div>

--- a/apps/frontend/src/components/ui/PeriodCreateOrEditDialog.tsx
+++ b/apps/frontend/src/components/ui/PeriodCreateOrEditDialog.tsx
@@ -89,12 +89,7 @@ export default function PeriodCreateOrEditDialog(props: props) {
         <Label htmlFor='name' className='text-right'>
           Név
         </Label>
-        <Input
-          id='name'
-          placeholder='Őszi jelentkezési időszak 2024'
-          onChange={(event) => setName(event.target.value)}
-          value={name}
-        />
+        <Input id='name' placeholder='2024. ősz' onChange={(event) => setName(event.target.value)} value={name} />
 
         <Label htmlFor='datepicker' className='text-right'>
           Időszak kezdete és vége

--- a/apps/frontend/src/components/ui/PictureUploadDialog.tsx
+++ b/apps/frontend/src/components/ui/PictureUploadDialog.tsx
@@ -30,6 +30,8 @@ export default function PictureUploadDialog({ children, aspectRatio, onChange, e
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      setZoom(1);
+      setCrop({ x: 0, y: 0 });
       const reader = new FileReader();
       reader.readAsDataURL(file);
       reader.onloadend = () => {

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -31,8 +31,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { closable?: boolean }
+>(({ className, children, closable = true, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -44,10 +44,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className='absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground'>
-        <X className='h-4 w-4' />
-        <span className='sr-only'>Close</span>
-      </DialogPrimitive.Close>
+      {closable && (
+        <DialogPrimitive.Close className='absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground'>
+          <X className='h-4 w-4' />
+          <span className='sr-only'>Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ));

--- a/apps/frontend/src/components/ui/generating-dialog.tsx
+++ b/apps/frontend/src/components/ui/generating-dialog.tsx
@@ -1,0 +1,17 @@
+import { CgSandClock } from 'react-icons/cg';
+
+import { Th2 } from '../typography/typography';
+import { Dialog, DialogContent } from './dialog';
+
+export function GeneratingDialog({ open }: { open: boolean }) {
+  return (
+    <Dialog open={open}>
+      <DialogContent className='sm:max-w-[425px]' closable={false}>
+        <div className='flex flex-col gap-4 w-full items-center'>
+          <CgSandClock className='animate-slow-spin' size={48} />
+          <Th2>Generálás...</Th2>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
this might not fix the whole issue, we still download ~900 images from the backend one-by-one, but at least now the pass background is not downloaded ~900 times xd. I tested locally with the prod data and it was able to generate the ~900 passes, we'll have to try it prod tho.